### PR TITLE
Fix 20: Add alert message after new GitHub sign-up

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -14,8 +14,18 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         redirect_to :home_index_path, alert: 'Couldn\'t connect with GitHub account'
       end
     else
-      @user = User.from_omniauth(request.env['omniauth.auth'])
-      sign_in_and_redirect @user
+      user = User.from_omniauth(request.env['omniauth.auth'])
+      if user
+        @user = user
+        sign_in_and_redirect @user
+      else
+        redirect_to new_user_session_path,
+                    alert: "Sign-ups are disabled because we are currently in closed beta.<br />" \
+                           "We are delighted to know that you're excited about Hyperlog! " \
+                           "Join the waitlist here at <a href='https://hyperlog.io'><u>Hyperlog.io</u></a> " \
+                           "to be among the first to get access as we open up.",
+                    flash: { html_alert: true }  # a hacky way to pass parameters, remove this later
+      end
     end
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -74,7 +74,7 @@
         <div class="mt-6">
           <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: 'space-y-6'}) do |f| %>
             <div>
-              <%= f.label "Username/Email", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label "Username or email address", class: "block text-sm font-medium text-gray-700" %>
               <div class="mt-1">
                 <%= f.text_field :login, autofocus: true, autocomplete: "username", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm" %>
               </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,8 @@
               </div>
               <div class="ml-3">
                 <h3 class="text-sm font-medium text-red-800">
-                  <%= alert %>
+                  <%# this skips escaping so as to allow HTML <a> tag in the alert box. must be reverted later %>
+                  <%= flash['html_alert'] ? raw(alert) : alert %> 
                 </h3>
               </div>
             </div>


### PR DESCRIPTION
- Change 'Username/email' to 'Username or email address'
- Add message after github signup is declined

Closes #20
